### PR TITLE
Add toolinfo.json to src/static

### DIFF
--- a/src/static/toolinfo.json
+++ b/src/static/toolinfo.json
@@ -1,0 +1,11 @@
+[
+    {
+      "name" : "locator-tool",
+      "title" : "locator-tool",
+      "description" : "Helps to add {{Location}} information to images on Wikimedia Commons.",
+      "url" : "https://tools.wmflabs.org/locator-tool/",
+      "keywords" : "geolocation, coordinates, map, Commons",
+      "author" : "Simon04",
+      "repository" : "https://github.com/simon04/locator-tool"
+    }
+]


### PR DESCRIPTION
Hello,

I was just pointed out to this tool − it looks quite neat :)

I noticed it is not discoverable via [Hay’s Tools Directory](http://tools.wmflabs.org/hay/directory/), that I believe many users rely on to navigate the myriad of cool tools on ToolLabs

In case you are interested in this, here is a PR for a `toolinfo.json` file.