### PR TITLE
Update links to Transifex

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The application consists of:
 
 ## Translate
 
-- Translations are done at [transifex.com/locator-tool](https://www.transifex.com/locator-tool/locator-tool/dashboard/)
+- Translations are done at [transifex.com/locator-tool](https://app.transifex.com/locator-tool/locator-tool/dashboard/)
 
 ## Author and License
 

--- a/app/README.md
+++ b/app/README.md
@@ -16,6 +16,6 @@ The frontend is a [Vue.js 3](https://vuejs.org/) application.
 
 ## Translations
 
-- Translations are done at [transifex.com/locator-tool](https://www.transifex.com/locator-tool/locator-tool/dashboard/)
+- Translations are done at [transifex.com/locator-tool](https://app.transifex.com/locator-tool/locator-tool/dashboard/)
 - To update the translation template (POT file), run `$ bun run pot`, followed by an upload to Transifex using `$ tx push -s`
 - To update the translated files (PO files), run `$ tx pull`, followed by `$ bun run po`

--- a/app/components/ltAbout.vue
+++ b/app/components/ltAbout.vue
@@ -43,7 +43,7 @@
       </a>
     </li>
     <li>
-      <a href="https://www.transifex.com/locator-tool/locator-tool/" class="icon-link">
+      <a href="https://app.transifex.com/locator-tool/locator-tool/" class="icon-link">
         <ChatLeft />
         <span>{{ t('Translate locator-tool on Transifex') }}</span>
       </a>


### PR DESCRIPTION
Transifex changed the domain from https://www.transifex.com to https://app.transifex.com a while ago. The old domain brings the user to a 404 page.

Source: https://help.nextcloud.com/t/transifex-announcement-web-applications-domain-change/159445 and https://web.archive.org/web/20230330153241/http://help.transifex.com/en/articles/7171815-web-application-s-domain-change